### PR TITLE
Linter added. #16

### DIFF
--- a/.jscs.json
+++ b/.jscs.json
@@ -1,0 +1,4 @@
+{
+  "disallowMixedSpacesAndTabs": true,
+  "validateIndentation": 2
+}

--- a/core/app.js
+++ b/core/app.js
@@ -32,7 +32,7 @@ if(config.debug) {
       }
       fs.writeFileSync(path.join(pubdir, filename + '.css'), css);
     }
-	yield next;
+    yield next;
   });
 }
 

--- a/package.json
+++ b/package.json
@@ -18,9 +18,11 @@
     "q": "~1.1.1"
   },
   "devDependencies": {
+    "jscs": "^1.8.1",
     "node-sass": "^0.9.6"
   },
   "scripts": {
+    "pretest": "$(npm bin)/jscs core --esnext --config=./.jscs.json",
     "test": "$(npm bin)/mocha -t 5000 --require co-mocha --harmony tests/"
   },
   "repository": {


### PR DESCRIPTION
We can be as [strict as we want](https://github.com/jscs-dev/node-jscs#rules), but right now this just makes sure tabs and spaces aren't used in the same line, and that our indentation level is two spaces.
