### PR TITLE
Fixes a bug where `npm start` won't load environment variables on some systems

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   "scripts": {
     "pretest": "$(npm bin)/jscs core --esnext --config=./.jscs.json",
     "test": "$(npm bin)/mocha --require co-mocha --harmony tests/",
-    "start": "bash -c 'if [ -a ~/.pam_environment ]; then eval \"$(< ~/.pam_environment)\" node --harmony core/app; else node --harmony core/app; fi'",
+    "start": "if [ test -a ~/.pam_environment ]; then (export $(sed 's/#.*//' ~/.pam_environment | tr '\n' ' ') && node --harmony core/app); else node --harmony core/app; fi",
     "postinstall": "bash -c 'if [ \"$HLRDESK_DEV\" = \"true\" ]; then psql -c \"DROP SCHEMA IF EXISTS public cascade ;CREATE SCHEMA public;\"; psql < core/db/schema.sql; fi'",
     "compile-sass": "./.compile-sass.sh",
     "deploy": "./.deploy.sh"


### PR DESCRIPTION
Ostensibly on older versions of Bash (pre-4.3)