### PR TITLE
Allows for passing arguments to mocha via 'npm test'

### DIFF
--- a/.run-tests.sh
+++ b/.run-tests.sh
@@ -22,4 +22,4 @@ psql -c "DROP DATABASE IF EXISTS $TEST_DB" >/dev/null
 printf "."
 createdb $TEST_DB -T $TEMPLATE_DB >/dev/null
 printf " Done!\n"
-PGPOOLSIZE=0 PGDATABASE=$TEST_DB TEMPLATE_DB=$TEMPLATE_DB $(npm bin)/mocha --require co-mocha --harmony tests/
+PGPOOLSIZE=0 PGDATABASE=$TEST_DB TEMPLATE_DB=$TEMPLATE_DB $(npm bin)/mocha --require co-mocha --harmony tests/ "$@"


### PR DESCRIPTION
E.g.,

* `npm test -- --reporter nyan`
* `npm test -- --reporter dot`
* `npm test -- --reporter list --grep "inventory must"`
* `npm test -- --bail`
* [etc.](http://mochajs.org/#usage)