### PR TITLE
Handles bug with Travis builds not closing DB connections quickly enough

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,9 +75,5 @@ after_script:
   - echo "See build screenshots on https://byu-odh.github.io/hlrdesk"
 
 
-# TODO: Travis won't let us conditionally use this in after_success
-#addons:
-#  ssh_known_hosts:
-#  - hlrdesk.hlrdev.byu.edu
-#  - hlrdesk-staging.byu.edu
-#  - hlrdesk-prod.byu.edu
+addons:
+  postgresql: "9.3"

--- a/tests/resetdb.js
+++ b/tests/resetdb.js
@@ -2,8 +2,13 @@ prom_spawn = require('prom-spawn');
 const ENV = process.env;
 
 function resetDB(callback) {
-  // note that ENV.PGDATABASE is set by the .run-tests.sh
-  prom_spawn('dropdb',ENV.PGDATABASE,'--if-exists')()
+  // note that ENV.PGDATABASE is set by the .run-tests.sh file
+  var killQuery = "SELECT pg_terminate_backend(pg_stat_activity.pid) " +
+                  "FROM pg_stat_activity " +
+                  "WHERE pg_stat_activity.datname='" + ENV.PGDATABASE + "' " +
+                  "AND pid <> pg_backend_pid();";
+  prom_spawn('psql', '-c', killQuery)()
+    .then(prom_spawn('dropdb',ENV.PGDATABASE,'--if-exists'))
     .then(prom_spawn('createdb',ENV.PGDATABASE,'-T',ENV.TEMPLATE_DB))
     .then(callback);
 }


### PR DESCRIPTION
Should fix the problem with the occasional build failure caused by `dropdb: database removal failed: ERROR:  database "hlrdesk_test_db" is being accessed by other users`