### PR TITLE
changed date added, date edited, and edited by fields to not have an input

### DIFF
--- a/core/templates/edit-catalog.html
+++ b/core/templates/edit-catalog.html
@@ -65,17 +65,17 @@
   </tr>
   <tr>
     <td><label for=dateAdded>Date Added</label></td>
-    <td><input type=date id="dateAdded" disabled=disabled></td>
+    <td><span id="dateAdded"></span></td>
   </tr>
     <tr>
     <td><label for=editedBy>Last Edited By</label></td>
-    <td><input id="editedBy" disabled=disabled></td>
+    <td><span id="editedBy"></span></td>
   </tr>
   <tr>
     <td><label for=dateEdited>Date Edited</label></td>
-    <td><input id="dateEdited" disabled=disabled></td>
+    <td><span id="dateEdited"></span></td>
   </tr>
-    <tr>
+  <tr>
     <td><label for=notes>Notes/Alert Field</label></td>
     <td><input id="notes"></td>
   </tr>

--- a/public/js/edit-catalog.js
+++ b/public/js/edit-catalog.js
@@ -93,22 +93,22 @@ window.HLRDESK.init.editCatalog = function() {
       var date = result.date_added.substring(0,10);
     }
 
-    $('#dateAdded').val(date);
+    $('#dateAdded').html(date);
 
-    $('#editedBy').val(result.edited_by);
+    $('#editedBy').html(result.edited_by);
 
-    if ($('#editedBy').val())
+    if ($('#editedBy').html())
     {
       if(result.date_edited)
       {
         var edited = result.date_edited.substring(0,10);
         $('#dateEdited').attr('type', 'date');
-        $('#dateEdited').val(edited);
+        $('#dateEdited').html(edited);
       }
     }
     else{
-      $('#dateEdited').val(" N/A");
-      $('#editedBy').val(" N/A");
+      $('#dateEdited').html(" N/A");
+      $('#editedBy').html(" N/A");
      }
 
     $('#notes').val(result.notes);

--- a/public/js/edit-catalog.js
+++ b/public/js/edit-catalog.js
@@ -93,22 +93,22 @@ window.HLRDESK.init.editCatalog = function() {
       var date = result.date_added.substring(0,10);
     }
 
-    $('#dateAdded').html(date);
+    $('#dateAdded').text(date);
 
-    $('#editedBy').html(result.edited_by);
+    $('#editedBy').text(result.edited_by);
 
-    if ($('#editedBy').html())
+    if ($('#editedBy').text())
     {
       if(result.date_edited)
       {
         var edited = result.date_edited.substring(0,10);
         $('#dateEdited').attr('type', 'date');
-        $('#dateEdited').html(edited);
+        $('#dateEdited').text(edited);
       }
     }
     else{
-      $('#dateEdited').html(" N/A");
-      $('#editedBy').html(" N/A");
+      $('#dateEdited').text(" N/A");
+      $('#editedBy').text(" N/A");
      }
 
     $('#notes').val(result.notes);


### PR DESCRIPTION
By getting rid of the input, the fields become unquestionably un-editable. Users will not try to edit those fields, but will still be able to see the info stored.