### PR TITLE
set app.keys equal to env var, changed set cookies to signed true

### DIFF
--- a/core/app.js
+++ b/core/app.js
@@ -33,7 +33,7 @@ process.on("uncaughtException", function(err) {
   throw err;
 });
 
-app.keys = ['TODO MAKE ME AN ENV VARIABLE', 'I SHOULD NOT BE HARDCODED', 'MY DOG HAS NO NOSE', 'HOW DOES HE SMELL?', 'AWFUL'];
+app.keys = [ENV.COOKIE_KEY];
 app.use(session());
 
 app.use(serve(path.join(__dirname, '..', 'public')));

--- a/core/app_modules/auth.js
+++ b/core/app_modules/auth.js
@@ -52,7 +52,7 @@ module.exports = {
      * wouldn't be necessary, and it may very well not be if
      * someone can get the tests to otherwise work.
      */
-    ctx.cookies.set('token', token, {maxAge: 0});
+    ctx.cookies.set('token', token, {maxAge: 0, signed: true});
 
     redisClient.sadd([token, obj.username]);
     redisClient.expire(token, 43200);


### PR DESCRIPTION
@webnard Its a literal implementation of what you suggested. Seemed to work. However I could not figure out how to set the environment variable as an array.

**Edit:** Also how can we add `COOKIE_KEY` to dev and production servers?